### PR TITLE
Add a readonly parameter to the constructor

### DIFF
--- a/diced/DicedRepo.py
+++ b/diced/DicedRepo.py
@@ -55,7 +55,7 @@ class DicedRepo(object):
     RestrictionName = "restrictions"
     InstanceMetaPrefix = "instance:"
 
-    def __init__(self, server, uuid, dicedstore):
+    def __init__(self, server, uuid, dicedstore, readonly=False):
         self.server = server
         
         # create connection object to DVID
@@ -88,10 +88,14 @@ class DicedRepo(object):
         self._init_version(uuid)
 
         # create meta types if not currently available
-        if self.MetaLocation not in self.activeinstances:
-            self.nodeconn.create_keyvalue(self.MetaLocation)
-        if self.FilesLocation not in self.activeinstances:
-            self.nodeconn.create_keyvalue(self.FilesLocation)
+        # This operation is not available if the DVID server is running in
+        # readonly mode, but most of this library will still work if it is.
+        # Supplying readonly=True in the constructor will bypass this initialisation.
+        if not readonly:
+            if self.MetaLocation not in self.activeinstances:
+                self.nodeconn.create_keyvalue(self.MetaLocation)
+            if self.FilesLocation not in self.activeinstances:
+                self.nodeconn.create_keyvalue(self.FilesLocation)
 
     def change_version(self, uuid):
         """Change the current node version.

--- a/diced/DicedStore.py
+++ b/diced/DicedStore.py
@@ -327,7 +327,7 @@ max_log_age = 30   # days
                 return repoid
         raise DicedException("repo name does not exist")
 
-    def open_repo(self, name=None, uuid=None):
+    def open_repo(self, name=None, uuid=None, readonly=False):
         """Open repository of the specified name (or by unique identifier).
 
         If only the name is specified, the root node is taken by default.
@@ -346,7 +346,7 @@ max_log_age = 30   # days
         if uuid is not None:
             try:
                 ns = DVIDNodeService(self._server, uuid)
-                return DicedRepo(self._server, uuid, self)
+                return DicedRepo(self._server, uuid, self, readonly)
             except DVIDException:
                 # repo does not exist
                 raise DicedException("uuid does not exist")

--- a/diced/DicedStore.py
+++ b/diced/DicedStore.py
@@ -352,5 +352,5 @@ max_log_age = 30   # days
                 raise DicedException("uuid does not exist")
         elif name is not None:
             repoid = self.get_repouuid(name)
-            return DicedRepo(self._server, repoid, self)
+            return DicedRepo(self._server, repoid, self, readonly)
 


### PR DESCRIPTION
I'm not sure if this is the way you want to do this, or if you want to go through and make more involved tracking of readonly state and modify existing methods to suit. We needed this small change to get some code that uses this library to work with our (internet-accessible and thus readonly) DVID server.